### PR TITLE
adds demonstration that 2.14.1 of log4j is still vulnerable even with…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN gradle bootJar --no-daemon
 
 FROM openjdk:8u181-jdk-alpine
 EXPOSE 8080
+
+# Add environment variable as the currently official workaround for vulnerable versions of log4j2 (e.g. 2.14.1)
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS true
+
 RUN mkdir /app
 COPY --from=builder /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar
 CMD ["java", "-jar", "/app/spring-boot-application.jar"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+
+*Changes to original vulnerable application to demonstrate that workarounds can still be exploited in some circumstances*:
+- Included supposedly fix with `LOG4J_FORMAT_MSG_NO_LOOKUPS true` in [Dockerfile](Dockerfile)
+- Used **ThreadContextMap** to pass further content to logging in [MainController.java](src/main/java/fr/christophetd/log4shell/vulnerableapp/MainController.java)
+- Changed log format to use value from thread context map (`${ctx:apiversion}`) in new file [log4j2.properties](src/main/resources/log4j2.properties)
+
+**So even with `LOG4J_FORMAT_MSG_NO_LOOKUPS true` version 2.14.1 of log4j is vulnerable when using ThreadContextMap in PatternLayout.**
 # Log4Shell sample vulnerable application (CVE-2021-44228)
 
 This repository contains a Spring Boot web application vulnerable to CVE-2021-44228, nicknamed [Log4Shell](https://www.lunasec.io/docs/blog/log4j-zero-day/).

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,16 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+// uncomment this to force the usage of log4j2 2.15.0 which should not be vulnerable anymore
+
+// configurations.all {
+// 	resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+// 		if (details.requested.group == 'org.apache.logging.log4j') {
+// 			details.useVersion '2.15.0'
+// 		}
+// 	}
+// }
+
 test {
 	useJUnitPlatform()
 }

--- a/src/main/java/fr/christophetd/log4shell/vulnerableapp/MainController.java
+++ b/src/main/java/fr/christophetd/log4shell/vulnerableapp/MainController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 
 @RestController
 public class MainController {
@@ -15,7 +16,12 @@ public class MainController {
 
     @GetMapping("/")
     public String index(@RequestHeader("X-Api-Version") String apiVersion) {
-        logger.info("Received a request for API version " + apiVersion);
+        
+        // Add user controlled input to threadcontext;
+        // Used in log via ${ctx:apiversion}
+        ThreadContext.put("apiversion", apiVersion); 
+
+        logger.info("Received a request for API version ");
         return "Hello, world!";
     }
 

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,26 @@
+status = error
+name = PropertiesConfig
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = debug
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+
+# vulnerable in 2.14.1 even with ENV LOG4J_FORMAT_MSG_NO_LOOKUPS true
+appender.console.layout.pattern = ${ctx:apiversion} - %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+# vulnerable in 2.14.1 even with ENV LOG4J_FORMAT_MSG_NO_LOOKUPS true
+#appender.console.layout.pattern = $${ctx:apiversion} - %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+# seems to be protected by nolookups
+#appender.console.layout.pattern = %X - %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+rootLogger.level = debug
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
… "OG4J_FORMAT_MSG_NO_LOOKUPS true"